### PR TITLE
Add privacy policy checkbox button for Spotify compliance

### DIFF
--- a/frontend/components/shared/JGButton/JGButton.tsx
+++ b/frontend/components/shared/JGButton/JGButton.tsx
@@ -3,6 +3,7 @@ import { View, TouchableOpacity, Image, Text, StyleSheet, ViewStyle, StyleProp, 
 
 export type JGButtonProps = {
     title?: string;
+    clickable?: boolean;
     icon?: JGButtonImageType;
     style?: StyleProp<ViewStyle>;
     fillParent?: boolean;
@@ -17,6 +18,7 @@ export default function JGButton(props: JGButtonProps) {
     // let image = props.imagePath ? <Image source={require(props.imagePath)} style={{ width: 20, height: 20 }} /> : null;
     let isLoading = props.isLoading ?? false;
     let wrapperStyle = props.fillParent ? { ...styles.wrapperView, ...styles.fullWidth } : styles.wrapperView;
+    let clickableStyle = props.clickable || props.clickable == null ? { ...styles.clickableTrue } : { ...styles.clickableFalse };
     let imagePath = props.icon ? require("./images/spotify-logo.png") : null;
     console.log(imagePath);
     let image = props.icon ? <Image style={styles.image} source={imagePath} /> : null;
@@ -29,7 +31,7 @@ export default function JGButton(props: JGButtonProps) {
     return (
         <View style={props.style}>
             <TouchableOpacity onPress={props.onClick}>
-                <View style={wrapperStyle}>
+                <View style={[wrapperStyle, clickableStyle]}>
                     {image}
                     {title}
                     {loadingView}
@@ -54,11 +56,16 @@ const styles = StyleSheet.create({
     wrapperView: {
         flex: 0,
         flexDirection: "row",
-        backgroundColor: "#7432FF",
         paddingHorizontal: 20,
         borderRadius: 50,
         alignItems: "center",
         justifyContent: "center",
+    },
+    clickableTrue: {
+        backgroundColor: "#7432FF",
+    },
+    clickableFalse: {
+        backgroundColor: "#483b63",
     },
     fullWidth: {
         width: "100%",

--- a/frontend/ios/Euphony.xcodeproj/project.pbxproj
+++ b/frontend/ios/Euphony.xcodeproj/project.pbxproj
@@ -410,7 +410,6 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Euphony/Pods-Euphony-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-
 		1B923D0B611770BA092FB284 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -480,23 +479,6 @@
 				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Euphony-EuphonyTests/Pods-Euphony-EuphonyTests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Euphony-EuphonyTests/Pods-Euphony-EuphonyTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		A3825666AFE06C2EB7ADE573 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Euphony-EuphonyTests/Pods-Euphony-EuphonyTests-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Euphony-EuphonyTests/Pods-Euphony-EuphonyTests-resources-${CONFIGURATION}-output-files.xcfilelist",
 			);

--- a/frontend/ios/Podfile.lock
+++ b/frontend/ios/Podfile.lock
@@ -364,6 +364,8 @@ PODS:
     - React-Core
   - RNCAsyncStorage (1.16.1):
     - React-Core
+  - RNCCheckbox (0.5.12):
+    - React-Core
   - RNFastImage (8.5.11):
     - React-Core
     - SDWebImage (~> 5.11.1)
@@ -449,6 +451,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - ReactNativeGetLocation (from `../node_modules/react-native-get-location`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
+  - "RNCCheckbox (from `../node_modules/@react-native-community/checkbox`)"
   - RNFastImage (from `../node_modules/react-native-fast-image`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReactNativeHapticFeedback (from `../node_modules/react-native-haptic-feedback`)
@@ -549,6 +552,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-get-location"
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
+  RNCCheckbox:
+    :path: "../node_modules/@react-native-community/checkbox"
   RNFastImage:
     :path: "../node_modules/react-native-fast-image"
   RNGestureHandler:
@@ -615,6 +620,7 @@ SPEC CHECKSUMS:
   ReactCommon: 650e33cde4fb7d36781cd3143f5276da0abb2f96
   ReactNativeGetLocation: d6b15cb2a2023ab7703f756501bad86d3ecf6fea
   RNCAsyncStorage: b49b4e38a1548d03b74b30e558a1d18465b94be7
+  RNCCheckbox: ed1b4ca295475b41e7251ebae046360a703b6eb5
   RNFastImage: 1f2cab428712a4baaf78d6169eaec7f622556dd7
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReactNativeHapticFeedback: 4085973f5a38b40d3c6793a3ee5724773eae045e

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^1.16.1",
+        "@react-native-community/checkbox": "^0.5.12",
         "@react-native-community/slider": "^4.1.12",
         "@react-navigation/bottom-tabs": "^6.0.9",
         "@react-navigation/elements": "^1.3.1",
@@ -2713,6 +2714,21 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || 0.60 - 0.67 || 1000.0.0"
+      }
+    },
+    "node_modules/@react-native-community/checkbox": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@react-native-community/checkbox/-/checkbox-0.5.12.tgz",
+      "integrity": "sha512-Dd3eiAW7AkpRgndwKGdgQ6nNgEmZlVD8+KAOBqwjuZQ/M67BThXJ9Ni+ydpPjNm4e28KXmIILfkvhcDt0ZoFTQ==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": ">= 0.62",
+        "react-native-windows": ">=0.62"
+      },
+      "peerDependenciesMeta": {
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native-community/cli": {
@@ -16420,6 +16436,12 @@
       "requires": {
         "merge-options": "^3.0.4"
       }
+    },
+    "@react-native-community/checkbox": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@react-native-community/checkbox/-/checkbox-0.5.12.tgz",
+      "integrity": "sha512-Dd3eiAW7AkpRgndwKGdgQ6nNgEmZlVD8+KAOBqwjuZQ/M67BThXJ9Ni+ydpPjNm4e28KXmIILfkvhcDt0ZoFTQ==",
+      "requires": {}
     },
     "@react-native-community/cli": {
       "version": "6.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.16.1",
+    "@react-native-community/checkbox": "^0.5.12",
     "@react-native-community/slider": "^4.1.12",
     "@react-navigation/bottom-tabs": "^6.0.9",
     "@react-navigation/elements": "^1.3.1",

--- a/frontend/screens/login/LoginScreen.tsx
+++ b/frontend/screens/login/LoginScreen.tsx
@@ -1,13 +1,18 @@
 import * as React from 'react';
-import { SafeAreaView, TouchableOpacity, StyleSheet, Button, Text, View, Image, ImageBackground } from 'react-native';
+import { SafeAreaView, TouchableOpacity, StyleSheet, Button, Text, View, Image, ImageBackground, Linking } from 'react-native';
+
 import { authHandler } from '../../networking/Endpoints';
 import AppContext from '../../AppContext';
+
 import JGButton, { JGButtonImageType } from '../../components/shared/JGButton/JGButton';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
+import CheckBox from '@react-native-community/checkbox';
 
 export default function LoginScreen({ dismissAction }: { dismissAction: () => void }) {
     const authContext = React.useContext(AppContext);
     let [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+
+    const [toggleCheckbox, setToggleCheckbox] = React.useState(false);
 
     let errorBody: Element | null = <Text style={{
         color: 'red',
@@ -51,10 +56,26 @@ export default function LoginScreen({ dismissAction }: { dismissAction: () => vo
 
                             <Text style={styles.baseText}>For more personalized results, we recommend that you connect your Spotify account.</Text>
                         </View>
-
-
                     </View>
-                    <JGButton style={{ marginTop: 20 }} icon={JGButtonImageType.Spotify} title="CONNECT SPOTIFY" onClick={async () => {
+                    {/* Add checkbox for user to consent to privacy policy */}
+                    <View style={styles.privacyPolicyContainer}>
+                        
+                        <CheckBox
+                            value={toggleCheckbox}
+                            onValueChange={value =>
+                                setToggleCheckbox(!toggleCheckbox)
+                            }
+                        />
+                        <Text style={styles.baseText}>I have read and agree {'\n'}to 
+                            the <Text onPress={() => Linking.openURL('https://alanyan.ca/Euphony/privacy')} style={styles.underline}>Privacy Policy</Text>
+                        </Text>
+                    </View>
+
+                    <JGButton clickable={toggleCheckbox} style={{ marginTop: 20 }} icon={JGButtonImageType.Spotify} title="CONNECT SPOTIFY" onClick={async () => {
+                        if (!toggleCheckbox) {  
+                            setErrorMessage("Please agree to the privacy policy before continuing.");
+                            return;
+                        }
                         try {
                             setErrorMessage(null);
                             let result = await authHandler.onLogin();
@@ -119,7 +140,16 @@ const styles = StyleSheet.create({
         flex: 1,
         justifyContent: 'center',
         marginHorizontal: 40,
-    }
+    },
+    privacyPolicyContainer: {
+        justifyContent: "space-evenly", 
+        alignItems: "center", 
+        flexDirection: "row", 
+        alignContent: "center",
+    },
+    underline: {
+        textDecorationLine: 'underline'
+    },
 });
 
 

--- a/frontend/screens/onboarding/OnboardingScreen.tsx
+++ b/frontend/screens/onboarding/OnboardingScreen.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { SafeAreaView, TouchableHighlight, StyleSheet, Button, Text, View, Image, ImageBackground, Alert, StatusBar } from 'react-native';
+import { SafeAreaView, TouchableHighlight, StyleSheet, Button, Text, View, Image, ImageBackground, Alert, StatusBar, Linking } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import AppContext from '../../AppContext';
 import { authHandler } from '../../networking/Endpoints';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
+import CheckBox from '@react-native-community/checkbox';
 
 function OnboardingScreen(props) {
     const globalContext = React.useContext(AppContext);
@@ -90,6 +91,8 @@ function OnboardingScreen(props) {
     }
 
     function ScrollC() {
+        const [toggleCheckbox, setToggleCheckbox] = React.useState(false);
+
         return (
             <View style={styles.cardContainer}>
                 <Text style={styles.skipText} onPress={() => {
@@ -111,6 +114,19 @@ function OnboardingScreen(props) {
                     <View style={styles.pageIndicator}>
                         <Text style={styles.pageIndicatorTxt}>3 of 3</Text>
                     </View>
+
+                    {/* Add checkbox for user to consent to privacy policy */}
+                    <View style={styles.privacyPolicyContainer}>
+                        <CheckBox
+                            value={toggleCheckbox}
+                            onValueChange={() =>
+                                setToggleCheckbox(!toggleCheckbox)
+                            }
+                        />
+                        <Text style={styles.baseText}>I have read and agree {'\n'}to 
+                            the <Text onPress={() => Linking.openURL('https://alanyan.ca/Euphony/privacy')} style={styles.underline}>Privacy Policy</Text>
+                        </Text>
+                    </View>
                 </View>
 
                 <TouchableHighlight style={styles.leftButton} onPress={() => setPage(<ScrollB />)} underlayColor="#9663ff">
@@ -118,6 +134,10 @@ function OnboardingScreen(props) {
                 </TouchableHighlight>
 
                 <TouchableHighlight style={[styles.spotifyButtonContainer, styles.shadowPropIOS, styles.shadowPropAndroid]} onPress={async () => {
+                    if (!toggleCheckbox) {
+                        Alert.alert("Please agree to the privacy policy before continuing.");
+                        return;
+                    }
                     try {
                         let result = await authHandler.onLogin();
                         globalContext.setUserID(result.userID);
@@ -132,7 +152,7 @@ function OnboardingScreen(props) {
                         }
                     }
                 }} underlayColor="#9663ff">
-                    <View style={styles.spotifyButton}>
+                    <View style={[styles.spotifyButton, toggleCheckbox ? styles.clickableTrue : styles.clickableFalse]}>
                         <Image source={require('./images/spotify-logo.png')} style={{ width: 22, height: 33, resizeMode: 'stretch' }} />
                         <Text style={styles.spotifyText}>CONNECT SPOTIFY</Text>
                     </View>
@@ -146,7 +166,8 @@ function OnboardingScreen(props) {
 const styles = StyleSheet.create({
     main: {
         backgroundColor: 'white',
-        flex: 1
+        flex: 1,
+        paddingTop: 20,
     },
     cardContainer: {
         display: "flex",
@@ -298,10 +319,24 @@ const styles = StyleSheet.create({
         alignItems: "center",
         justifyContent: "space-between",
         borderRadius: 50,
-        backgroundColor: "#7432FF",
         paddingRight: 25,
         paddingLeft: 25
-    }
+    },
+    privacyPolicyContainer: {
+        justifyContent: "space-evenly", 
+        alignItems: "center", 
+        flexDirection: "row", 
+        alignContent: "center",
+    },
+    underline: {
+        textDecorationLine: 'underline'
+    },
+    clickableTrue: {
+        backgroundColor: "#7432FF",
+    },
+    clickableFalse: {
+        backgroundColor: "#483b63",
+    },
 });
 
 

--- a/frontend/screens/onboarding/OnboardingScreen.tsx
+++ b/frontend/screens/onboarding/OnboardingScreen.tsx
@@ -16,13 +16,13 @@ function OnboardingScreen(props) {
     }, [page]);
 
     return (
-        <SafeAreaView style={styles.main}>
+        <View style={styles.main}>
             <StatusBar translucent barStyle="dark-content" backgroundColor="transparent" />
 
             <ImageBackground source={require('./images/onboarding-background.png')} style={{ flex: 1 }}>
                 {page}
             </ImageBackground>
-        </SafeAreaView>
+        </View>
     );
 
     function ScrollA() {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1340,6 +1340,11 @@
   dependencies:
     "merge-options" "^3.0.4"
 
+"@react-native-community/checkbox@^0.5.12":
+  "integrity" "sha512-Dd3eiAW7AkpRgndwKGdgQ6nNgEmZlVD8+KAOBqwjuZQ/M67BThXJ9Ni+ydpPjNm4e28KXmIILfkvhcDt0ZoFTQ=="
+  "resolved" "https://registry.npmjs.org/@react-native-community/checkbox/-/checkbox-0.5.12.tgz"
+  "version" "0.5.12"
+
 "@react-native-community/cli-debugger-ui@^6.0.0-rc.0":
   "integrity" "sha512-onf6vtvqSzOr6bNEWhPzgcJP2UQhA0VY6c8tXwNczIONC/ahnN93LPBB/uXDbn9d/kLMvE7oUJiqRadZWHk6aA=="
   "resolved" "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-6.0.0.tgz"
@@ -6123,7 +6128,7 @@
     "prop-types" "^15.7.2"
     "yargs" "^16.1.1"
 
-"react-native@*", "react-native@^0.0.0-0 || 0.60 - 0.67 || 1000.0.0", "react-native@> 0.50.0", "react-native@>=0.42.0", "react-native@>=0.48.4", "react-native@>=0.50.0", "react-native@>=0.55", "react-native@>=0.60", "react-native@>=0.60.0", "react-native@>=0.63.0", "react-native@>=0.65.0", "react-native@0.67.3":
+"react-native@*", "react-native@^0.0.0-0 || 0.60 - 0.67 || 1000.0.0", "react-native@> 0.50.0", "react-native@>= 0.62", "react-native@>=0.42.0", "react-native@>=0.48.4", "react-native@>=0.50.0", "react-native@>=0.55", "react-native@>=0.60", "react-native@>=0.60.0", "react-native@>=0.63.0", "react-native@>=0.65.0", "react-native@0.67.3":
   "integrity" "sha512-epMVRMRH7dLCis97+YwiV4dmTVZO6qKmQgwcTNcxVt/kEMxAa+OYK7h81+99/n7XCeMFk/U2zYOBuQqc7c5Amg=="
   "resolved" "https://registry.npmjs.org/react-native/-/react-native-0.67.3.tgz"
   "version" "0.67.3"


### PR DESCRIPTION
To get access to user info in API scopes, Spotify is requiring us to explicitly confirm that the user has accepted our terms of usage in the privacy policy before logging in. They suggested a checkbox, so I did a checkbox

To-do:
- [ ] Confirm that all other buttons are still functional (I changed the JGButton class)
- [ ] Compiles on iOS?
- [ ] Compiles on Android?

Screenshots:

**Onboarding screen**
![image](https://user-images.githubusercontent.com/21225415/168462277-a53b0ab5-5627-483b-acc2-8231697bc670.png)

**Login screen**
![image](https://user-images.githubusercontent.com/21225415/168462286-78d11f2d-89e7-48fe-b373-5f2c49e8eab2.png)

**Login screen after accepting**
![image](https://user-images.githubusercontent.com/21225415/168462355-65ced4ef-59a3-42eb-811e-6b282aac4d2e.png)
